### PR TITLE
Remove circular refs from errors in assertNoError.

### DIFF
--- a/lib/test.js
+++ b/lib/test.js
@@ -120,8 +120,27 @@ function runMocha(state, callback) {
   global.assertNoError = err => {
     if(err) {
       const obj = err instanceof BedrockError ? err.toObject() : err;
+      // only one cache for each error.
+      const errorCache = new Set();
+      // JSON.stringify will call this for each key in the json
+      // we need to catch circular references here.
+      const removeCircularReferences = (key, value) => {
+        // javascript passes non-object primitives by value
+        // however objects (including functions & arrays) are by reference
+        if(typeof value === 'object' && value !== null) {
+          // if the value has already been cached it's a circular reference
+          if(errorCache.has(value)) {
+            return;
+          }
+          // otherwise cache it so we catch any future circular references
+          errorCache.add(value);
+        }
+        return value;
+      }
       console.error(
-        'An unexpected error occurred:', JSON.stringify(obj, null, 2));
+        'An unexpected error occurred:',
+        JSON.stringify(obj, removeCircularReferences, 2)
+      );
       throw err;
     }
   };

--- a/lib/test.js
+++ b/lib/test.js
@@ -4,6 +4,7 @@
 'use strict';
 
 const bedrock = require('bedrock');
+const cycle = require('cycle');
 const {config, util: {BedrockError}} = bedrock;
 const path = require('path');
 const {promisify} = require('util');
@@ -120,27 +121,15 @@ function runMocha(state, callback) {
   global.assertNoError = err => {
     if(err) {
       const obj = err instanceof BedrockError ? err.toObject() : err;
-      // only one cache for each error.
-      const errorCache = new Set();
-      // JSON.stringify will call this for each key in the json
-      // we need to catch circular references here.
-      const removeCircularReferences = (key, value) => {
-        // javascript passes non-object primitives by value
-        // however objects (including arrays) are by reference
-        if(typeof value === 'object' && value !== null) {
-          // if the value has already been cached it's a circular reference
-          if(errorCache.has(value)) {
-            return;
-          }
-          // otherwise cache it so we catch any future circular references
-          errorCache.add(value);
-        }
-        return value;
+      let pretty = null;
+      try {
+        pretty = JSON.stringify(obj, null, 2);
+      } catch(e) {
+        // we need to remove circular references from the json
+        // in order to pretty print with JSON.stringify
+        pretty = JSON.stringify(cycle.decycle(obj), null, 2);
       }
-      console.error(
-        'An unexpected error occurred:',
-        JSON.stringify(obj, removeCircularReferences, 2)
-      );
+      console.error('An unexpected error occurred: ', pretty);
       throw err;
     }
   };

--- a/lib/test.js
+++ b/lib/test.js
@@ -126,7 +126,7 @@ function runMocha(state, callback) {
       // we need to catch circular references here.
       const removeCircularReferences = (key, value) => {
         // javascript passes non-object primitives by value
-        // however objects (including functions & arrays) are by reference
+        // however objects (including arrays) are by reference
         if(typeof value === 'object' && value !== null) {
           // if the value has already been cached it's a circular reference
           if(errorCache.has(value)) {

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   "dependencies": {
     "chai": "^4.1.0",
     "chai-as-promised": "^7.1.1",
+    "cycle": "^1.0.3",
     "grunt": "~1.0.1",
     "grunt-cli": "^1.2.0",
     "grunt-contrib-watch": "^1.0.0",


### PR DESCRIPTION
This fixes a small bug in `assertNoError` with circular json in error objects:

```
     TypeError: Converting circular structure to JSON
      at JSON.stringify (<anonymous>)
      at global.assertNoError.err (node_modules/bedrock-test/lib/test.js:124:47)
      at Context.it (mocha/25-http-edv-client.js:215:7)
      at processTicksAndRejections (internal/process/task_queues.js:86:5)
```

it now removes circular references resulting in:

```
     Error: Request failed with status code 500
      at createError (node_modules/edv-client/node_modules/axios/lib/core/createError.js:16:15)
      at settle (node_modules/edv-client/node_modules/axios/lib/core/settle.js:18:12)
      at IncomingMessage.handleStreamEnd (node_modules/edv-client/node_modules/axios/lib/adapters/http.js:202:11)
      at IncomingMessage.EventEmitter.emit (domain.js:481:20)
      at endReadableNT (_stream_readable.js:1139:12)
      at processTicksAndRejections (internal/process/task_queues.js:81:17)
```

basically our error reporting structure can result in circular errors quite easily.
This makes it possible for `JSON.stringify` to print circular errors.


easy example:
```js
> var y = {b: null}
undefined
> var b = {y}
undefined
> b.y
{ b: null }
> y.b = b
{ y: { b: [Circular] } }
> JSON.stringify(y)
Thrown:
TypeError: Converting circular structure to JSON
    at JSON.stringify (<anonymous>)

```
