### PR TITLE
Use fork of grunt-shell.

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "grunt": "^1.4.1",
     "grunt-cli": "^1.4.3",
     "grunt-contrib-watch": "^1.1.0",
-    "grunt-shell": "^3.0.1",
+    "grunt-shell": "digitalbazaar/grunt-shell#update-strip-ansi",
     "mocha": "^9.1.1"
   },
   "peerDependencies": {


### PR DESCRIPTION
PR for `grunt-shell` submitted upstream.  Hopefully it will be accepted in short order.

https://github.com/sindresorhus/grunt-shell/pull/125

This is to address this:
```
                       === npm audit security report ===                        
                                                                                
┌──────────────────────────────────────────────────────────────────────────────┐
│                                Manual Review                                 │
│            Some vulnerabilities require your attention to resolve            │
│                                                                              │
│         Visit https://go.npm.me/audit-guide for additional guidance          │
└──────────────────────────────────────────────────────────────────────────────┘
┌───────────────┬──────────────────────────────────────────────────────────────┐
│ Moderate      │  Inefficient Regular Expression Complexity in                │
│               │ chalk/ansi-regex                                             │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Package       │ ansi-regex                                                   │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Patched in    │ >=5.0.1                                                      │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Dependency of │ grunt-shell                                                  │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Path          │ grunt-shell > strip-ansi > ansi-regex                        │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ More info     │ https://github.com/advisories/GHSA-93q8-gq69-wqmw            │
└───────────────┴──────────────────────────────────────────────────────────────┘
found 1 moderate severity vulnerability in 299 scanned packages
  1 vulnerability requires manual review. See the full report for details.

```